### PR TITLE
Fix typo in the helper command explanation text

### DIFF
--- a/.net
+++ b/.net
@@ -7,7 +7,7 @@ Usage: .net [command]
 Usage: .net [dotnet args]
 
 Helper commands:
-  sdk      Swtiches to a specific .NET Core SDK version
+  sdk      Switches to a specific .NET Core SDK version
   help     Display help
 
 dotnet args:

--- a/dotnet-sdk
+++ b/dotnet-sdk
@@ -7,7 +7,7 @@ Usage: dotnet sdk [command]
 Usage: dotnet sdk [version]
 
 Commands:
-  latest      Swtiches to the latest .NET Core SDK version
+  latest      Switches to the latest .NET Core SDK version
   list        Lists all installed .NET Core SDKs
   help        Display help
 


### PR DESCRIPTION
Fixes the typo "swtiches" to "switches".

Issue #22 