### PR TITLE
Creating install folder before downloading SDK

### DIFF
--- a/dotnet-sdk.cmd
+++ b/dotnet-sdk.cmd
@@ -102,7 +102,7 @@ echo Downloading .NET Core SDK version %version% for platform %platform%...
 echo %url%
 
 SET exe=.\installs\%version%.exe
-
+md .\installs
 powershell -Command "(New-Object Net.WebClient).DownloadFile('%url%', '%exe%')"
 echo Download completed. If succeeded the installation will start shortly.
 start %exe%


### PR DESCRIPTION
PowerShell throws an exception on downloading if the `./installs` folder doesn't exist before you try to save a downloaded item there.