### PR TITLE
tweak language of version description in help

### DIFF
--- a/dotnet-sdk
+++ b/dotnet-sdk
@@ -12,7 +12,7 @@ Commands:
   help        Display help
 
 Versions:
-  An installed version number of a .NET Core SDK"
+  The version number of a .NET Core SDK"
 }
 
 function sdk_list(){

--- a/dotnet-sdk.cmd
+++ b/dotnet-sdk.cmd
@@ -68,7 +68,7 @@ echo   get         Downloads the provided release version. ('' or 'latest' for t
 echo   help        Display help
 echo.
 echo version:
-echo   An installed version number of a .NET Core SDK
+echo   The version number of a .NET Core SDK
 echo.
 
 goto end


### PR DESCRIPTION
- When running `dotnet sdk get` the version is not yet "installed".
- An SDK only has one version so the definite article "_The_ version..." should be used rather than the indefinite article "_A_ version..."/"_An_ installed version...".