### PR TITLE
Update dotnet-sdk to work with latest structure

### DIFF
--- a/dotnet-sdk
+++ b/dotnet-sdk
@@ -17,7 +17,7 @@ Versions:
 
 function sdk_list(){
 	echo "The installed .NET Core SDKs are:"
-	ls -1 "/usr/local/share/dotnet/sdk"
+	ls -1 /usr/share/dotnet/sdk | sort | head -n -1
 }
 
 function sdk_latest(){


### PR DESCRIPTION
The sdk structure is now by default at `/usr/share/dotnet/sdk` for Mac and Linux.
See references:

https://docs.microsoft.com/en-us/dotnet/core/distribution-packaging
https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet#environment-variables
https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script#options

At this location there is also a directory called `NuGetFallbackFolder`, so I also added a `head` call to remove it.

Fixes #21.